### PR TITLE
Refactor GEM workspace allocation

### DIFF
--- a/src/gem/AddPureConPhase.f90
+++ b/src/gem/AddPureConPhase.f90
@@ -55,7 +55,7 @@ subroutine AddPureConPhase(iPhaseChange,lSwapLater,lPhasePass)
 
     implicit none
 
-    integer                       :: i, iPhaseChange, iterBack, INFO
+    integer                       :: i, iPhaseChange, iterBack, INFO, nVar
     integer, dimension(nElements) :: iAssemblageTest
     logical                       :: lPhasePass, lSwapLater
 
@@ -96,6 +96,8 @@ subroutine AddPureConPhase(iPhaseChange,lSwapLater,lPhasePass)
         iAssemblage(nConPhases)     = iPhaseChange
 
         ! Check to make sure that the phase change is acceptable:
+        nVar = nElements + nConPhases + nSolnPhases
+        call ResizeGEMWorkspace(nVar)
         call CheckPhaseChange(lPhasePass,INFO)
 
         if (.NOT.(lPhasePass)) then

--- a/src/gem/AddSolnPhase.f90
+++ b/src/gem/AddSolnPhase.f90
@@ -73,7 +73,7 @@ subroutine AddSolnPhase(iPhaseChange,lSwapLater,lPhasePass)
 
     implicit none
 
-    integer::                       i, j, k, iPhaseChange, INFO, nConPhasesLast, iterBack
+    integer::                       i, j, k, iPhaseChange, INFO, nConPhasesLast, iterBack, nVar
     integer,dimension(nElements)::  iAssemblageTest, iAssemblageLast
     real(8),dimension(nElements)::  dTempVec
     logical::                       lPhasePass, lSwapLater, lCompEverything
@@ -149,6 +149,8 @@ subroutine AddSolnPhase(iPhaseChange,lSwapLater,lPhasePass)
     LOOP_CheckAssemblage: do i = 1, j
 
         ! Check that the phase change is acceptable:
+        nVar = nElements + nConPhases + nSolnPhases
+        call ResizeGEMWorkspace(nVar)
         call CheckPhaseChange(lPhasePass,INFO)
 
         if ((INFO > nElements + nSolnPhases) .AND. (nConPhases > 0)) then

--- a/src/gem/CheckPhaseChange.f90
+++ b/src/gem/CheckPhaseChange.f90
@@ -48,7 +48,7 @@ subroutine CheckPhaseChange(lPhasePass,INFO)
 
     implicit none
 
-    integer  ::  i, j, INFO, nMiscPhases
+    integer  ::  i, j, INFO, nMiscPhases, nVar
     real(8)  ::  dTemp
     logical  ::  lPhasePass
 
@@ -99,7 +99,9 @@ subroutine CheckPhaseChange(lPhasePass,INFO)
         dTemp = 1D100
     end if
 
-    ! Establish the Hessian matrix and compute the direction vector:
+    ! Allocate workspace and compute the direction vector:
+    nVar = nElements + nConPhases + nSolnPhases
+    call ResizeGEMWorkspace(nVar)
     call GEMNewton(INFO)
 
     ! Reinitialize variables:

--- a/src/gem/GEMNewton.f90
+++ b/src/gem/GEMNewton.f90
@@ -138,32 +138,11 @@ subroutine GEMNewton(INFO)
     TryLoop: do iTry = 0, nMaxTry
         ! on retry we are going to use dummy phases
         if (iTry > 0) nVar = nElements * 2
-
-        ! Allocate or resize workspace if necessary:
-        if (.NOT. allocated(GEM_A) .OR. SIZE(GEM_A,1) /= nVar) then
-            if (allocated(GEM_A)) deallocate(GEM_A)
-            allocate(GEM_A(nVar, nVar))
-        end if
-        if (.NOT. allocated(GEM_B) .OR. SIZE(GEM_B) /= nVar) then
-            if (allocated(GEM_B)) deallocate(GEM_B)
-            allocate(GEM_B(nVar))
-        end if
-        if (.NOT. allocated(GEM_IPIV) .OR. SIZE(GEM_IPIV) /= nVar) then
-            if (allocated(GEM_IPIV)) deallocate(GEM_IPIV)
-            allocate(GEM_IPIV(nVar))
-        end if
-        if (.NOT. allocated(dUpdateVar) .OR. SIZE(dUpdateVar) /= nVar) then
-            if (allocated(dUpdateVar)) deallocate(dUpdateVar)
-            allocate(dUpdateVar(nVar))
-        end if
+        call ResizeGEMWorkspace(nVar)
 
         ! Initialize variables:
-        GEM_IPIV(1:nVar)        = 0
-        INFO                    = 0
-        GEM_A(1:nVar,1:nVar)    = 0D0
-        GEM_B(1:nVar)           = 0D0
-        dUpdateVar              = 0D0
-        dEffStoichSolnPhase     = 0D0
+        INFO                = 0
+        dEffStoichSolnPhase = 0D0
 
         do k = 1, nSolnPhases
             ! Absolute solution phase index:

--- a/src/gem/InitGEMSolver.f90
+++ b/src/gem/InitGEMSolver.f90
@@ -365,7 +365,7 @@ subroutine InitGemCheckSolnPhase
 
     implicit none
 
-    integer::   i, j, k, l, nConPhasesTemp
+    integer::   i, j, k, l, nConPhasesTemp, nVar
     integer,dimension(nElements):: iAssemblageLast
     real(8)::   dTemp
     logical::   lPhasePass

--- a/src/gem/InitGEMSolver.f90
+++ b/src/gem/InitGEMSolver.f90
@@ -63,7 +63,7 @@ subroutine InitGEMSolver
 
     implicit none
 
-    integer::                               i, j, k, l
+    integer::                               i, j, k, l, nVar
     integer,dimension(nElements)::          iAssemblageLast
     real(8)::                               dTemp, dSum
     real(8),dimension(-1:nSolnPhasesSys)::  dTempVec
@@ -306,6 +306,8 @@ subroutine InitGEMSolver
         LOOP_CheckPhaseAssemblage: do j = 1, i
 
                 ! Check to make sure that the phase can be added:
+                nVar = nElements + nConPhases + nSolnPhases
+                call ResizeGEMWorkspace(nVar)
                 call CheckPhaseChange(lPhasePass,k)
 
                 if (k == 0) then
@@ -411,6 +413,8 @@ subroutine InitGemCheckSolnPhase
                     call CompMolSolnPhase
 
                     ! Check to make sure that the phase can be added:
+                    nVar = nElements + nConPhases + nSolnPhases
+                    call ResizeGEMWorkspace(nVar)
                     call CheckPhaseChange(lPhasePass,l)
 
                     if (lPhasePass) then

--- a/src/gem/RemPureConPhase.f90
+++ b/src/gem/RemPureConPhase.f90
@@ -49,7 +49,7 @@ subroutine RemPureConPhase(iPhaseChange,lSwapLater,lPhasePass)
 
     implicit none
 
-    integer::                        i, j, k, iPhaseChange, INFO, nConPhasesLast
+    integer::                        i, j, k, iPhaseChange, INFO, nConPhasesLast, nVar
     integer,dimension(nConPhases)::  iTempVec
     real(8)::                        dTemp
     real(8),dimension(nConPhases)::  dTempVec
@@ -82,6 +82,8 @@ subroutine RemPureConPhase(iPhaseChange,lSwapLater,lPhasePass)
     k = MAX(1, nConPhases)
     do i = 1, k
 
+        nVar = nElements + nConPhases + nSolnPhases
+        call ResizeGEMWorkspace(nVar)
         call CheckPhaseChange(lPhasePass,INFO)
 
         if ((INFO > nElements + nSolnPhases) .AND. (nConPhases > 0)) then

--- a/src/gem/RemSolnAddPureConPhase.f90
+++ b/src/gem/RemSolnAddPureConPhase.f90
@@ -55,7 +55,7 @@ subroutine RemSolnAddPureConPhase(iPhaseAdd,iPhaseRem,lPhasePass)
 
     implicit none
 
-    integer::   j, iPhaseAdd, iPhaseRem, INFO, iTemp
+    integer::   j, iPhaseAdd, iPhaseRem, INFO, iTemp, nVar
     real(8)::   dTemp
     logical::   lPhasePass
 
@@ -91,6 +91,8 @@ subroutine RemSolnAddPureConPhase(iPhaseAdd,iPhaseRem,lPhasePass)
 
     else
         ! Check that this phase change is acceptable:
+        nVar = nElements + nConPhases + nSolnPhases
+        call ResizeGEMWorkspace(nVar)
         call CheckPhaseChange(lPhasePass,INFO)
 
         lRevertSystem = .FALSE.

--- a/src/gem/RemSolnPhase.f90
+++ b/src/gem/RemSolnPhase.f90
@@ -59,7 +59,7 @@ subroutine RemSolnPhase(iPhaseChange,lPhasePass)
 
     implicit none
 
-    integer::                      i, j, k, iPhaseChange, INFO, iSolnPhaseLastOld
+    integer::                      i, j, k, iPhaseChange, INFO, iSolnPhaseLastOld, nVar
     real(8)::                      dTemp
     real(8),dimension(nElements):: dTempVec
     logical::                      lPhasePass
@@ -103,6 +103,8 @@ subroutine RemSolnPhase(iPhaseChange,lPhasePass)
         j = MAX(1,nConPhases)
         LOOP_PhaseCheck: do i = 1, j
 
+            nVar = nElements + nConPhases + nSolnPhases
+            call ResizeGEMWorkspace(nVar)
             call CheckPhaseChange(lPhasePass,INFO)
 
             if ((INFO > nElements + nSolnPhases) .AND. (nConPhases > 0)) then

--- a/src/gem/SwapPureConForSolnPhase.f90
+++ b/src/gem/SwapPureConForSolnPhase.f90
@@ -67,7 +67,7 @@ subroutine SwapPureConForSolnPhase(iPhaseChange,lPhasePass)
 
     implicit none
 
-    integer                      :: i, j, k, iPhaseChange, INFO, iterBack
+    integer                      :: i, j, k, iPhaseChange, INFO, iterBack, nVar
     integer,dimension(nElements) :: iAssemblageTest
     real(8)                      :: dTemp
     real(8),dimension(nElements) :: dTempVec
@@ -126,6 +126,8 @@ subroutine SwapPureConForSolnPhase(iPhaseChange,lPhasePass)
         iAssemblage(nConPhases) = iPhaseChange
 
         ! Check that this phase change is acceptable:
+        nVar = nElements + nConPhases + nSolnPhases
+        call ResizeGEMWorkspace(nVar)
         call CheckPhaseChange(lPhasePass,INFO)
 
         if (nSolnPhases == 0) then

--- a/src/gem/SwapPureConPhase.f90
+++ b/src/gem/SwapPureConPhase.f90
@@ -51,7 +51,7 @@ subroutine SwapPureConPhase(iPhaseChange,lSwapLater,lPhasePass)
 
     implicit none
 
-    integer                       :: i, iPhaseChange, INFO, iterBack
+    integer                       :: i, iPhaseChange, INFO, iterBack, nVar
     integer, dimension(nElements) :: iAssemblageTest
     real(8), dimension(nElements) :: dTempVec
     logical                       :: lSwapLater, lPhasePass
@@ -88,6 +88,8 @@ subroutine SwapPureConPhase(iPhaseChange,lSwapLater,lPhasePass)
         iAssemblage(i)  = iPhaseChange
 
         ! Check that this phase change is acceptable:
+        nVar = nElements + nConPhases + nSolnPhases
+        call ResizeGEMWorkspace(nVar)
         call CheckPhaseChange(lPhasePass,INFO)
 
         if (lPhasePass) then

--- a/src/gem/SwapSolnForPureConPhase.f90
+++ b/src/gem/SwapSolnForPureConPhase.f90
@@ -57,7 +57,7 @@ subroutine SwapSolnForPureConPhase(iPhaseChange,lPhasePass)
 
     implicit none
 
-    integer                       :: i, j, k, iPhaseChange, INFO, iterBack
+    integer                       :: i, j, k, iPhaseChange, INFO, iterBack, nVar
     integer, dimension(nElements) :: iAssemblageTest, iAssemblageTemp
     real(8), dimension(nElements) :: dMolesPhaseTemp
     real(8), dimension(nSpecies)  :: dMolFractionTemp, dMolesSpeciesTemp
@@ -157,6 +157,8 @@ subroutine SwapSolnForPureConPhase(iPhaseChange,lPhasePass)
         call CompChemicalPotential(lCompEverything)
 
         ! Check that this phase change is acceptable:
+        nVar = nElements + nConPhases + nSolnPhases
+        call ResizeGEMWorkspace(nVar)
         call CheckPhaseChange(lPhasePass,INFO)
 
         lRevertSystem = .FALSE.

--- a/src/gem/SwapSolnPhase.f90
+++ b/src/gem/SwapSolnPhase.f90
@@ -65,7 +65,7 @@ subroutine SwapSolnPhase(iPhaseChange,lPhasePass)
 
     implicit none
 
-    integer                       :: i, j, k, l, iPhaseChange, INFO, iterBack
+    integer                       :: i, j, k, l, iPhaseChange, INFO, iterBack, nVar
     integer, dimension(nElements) :: iAssemblageTest, iAssemblageTemp
     real(8)                       :: dTemp
     real(8), dimension(nElements) :: dMolesPhaseTemp
@@ -151,6 +151,8 @@ subroutine SwapSolnPhase(iPhaseChange,lPhasePass)
         call CompChemicalPotential(lCompEverything)
 
         ! Check that this phase change is acceptable:
+        nVar = nElements + nConPhases + nSolnPhases
+        call ResizeGEMWorkspace(nVar)
         call CheckPhaseChange(lPhasePass,INFO)
 
         lRevertSystem = .FALSE.

--- a/src/gem/SwapSolnPhaseSpecific.f90
+++ b/src/gem/SwapSolnPhaseSpecific.f90
@@ -61,7 +61,7 @@ subroutine SwapSolnPhaseSpecific(iPhaseAdd,iPhaseRem,lPhasePass)
 
     implicit none
 
-    integer                       :: i, j, iPhaseAdd, iPhaseRem, INFO, iterBack
+    integer                       :: i, j, iPhaseAdd, iPhaseRem, INFO, iterBack, nVar
     integer, dimension(nElements) :: iAssemblageTest
     real(8)                       :: dTemp
     logical                       :: lPhasePass, lCompEverything, lSwapLater
@@ -107,6 +107,8 @@ subroutine SwapSolnPhaseSpecific(iPhaseAdd,iPhaseRem,lPhasePass)
     call CompChemicalPotential(lCompEverything)
 
     ! Check that this phase change is acceptable:
+    nVar = nElements + nConPhases + nSolnPhases
+    call ResizeGEMWorkspace(nVar)
     call CheckPhaseChange(lPhasePass,INFO)
 
     if (lPhasePass) then

--- a/src/module/ModuleGEMSolver.f90
+++ b/src/module/ModuleGEMSolver.f90
@@ -72,4 +72,29 @@ module ModuleGEMSolver
     logical                              ::  lDebugMode, lRevertSystem, lConverged
     logical, dimension(:),   allocatable ::  lSolnPhases, lMiscibility
 
+contains
+
+    subroutine ResizeGEMWorkspace(nVar)
+
+        implicit none
+
+        integer, intent(in) :: nVar
+
+        if (allocated(GEM_A))    deallocate(GEM_A)
+        if (allocated(GEM_B))    deallocate(GEM_B)
+        if (allocated(GEM_IPIV)) deallocate(GEM_IPIV)
+        if (allocated(dUpdateVar)) deallocate(dUpdateVar)
+
+        allocate(GEM_A(nVar, nVar))
+        allocate(GEM_B(nVar))
+        allocate(GEM_IPIV(nVar))
+        allocate(dUpdateVar(nVar))
+
+        GEM_A      = 0D0
+        GEM_B      = 0D0
+        GEM_IPIV   = 0
+        dUpdateVar = 0D0
+
+    end subroutine ResizeGEMWorkspace
+
 end module ModuleGEMSolver


### PR DESCRIPTION
## Summary
- centralize GEM solver workspace resizing in new `ResizeGEMWorkspace`
- invoke workspace sizing from Newton solver and phase manipulation routines

## Testing
- `./run_tests`
- `make -j2` *(fails: gfortran not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af2e2bcee8832294057b0b21bd8a59