### PR TITLE
Refactor JSON output path handling

### DIFF
--- a/src/exec/InputScriptMode.F90
+++ b/src/exec/InputScriptMode.F90
@@ -30,6 +30,7 @@ program ThermochimicaInputScriptMode
   real(8) :: dTempLow, dTempHigh, dDeltaT, dPressLow, dPressHigh, dDeltaP
   integer :: i, nT, j, nP, nSim
   character(16) :: intStr
+  character(:), allocatable :: cOutputFullPath
 
   ! Read input argument to get filename
   call get_command_argument(1, cInputFile)
@@ -60,8 +61,10 @@ program ThermochimicaInputScriptMode
     dDeltaP = (dPressHigh - dPressLow) / nT
   end if
 
+  cOutputFullPath = GetResolvedOutputFilePath()
+
   if (lWriteJSON) then
-    open(1, file= DATA_DIRECTORY // '../outputs/thermoout.json', &
+    open(1, file= cOutputFullPath, &
         status='REPLACE', action='write')
     write(1,*) '{'
     close (1)
@@ -91,7 +94,7 @@ program ThermochimicaInputScriptMode
       ! Perform post-processing of results:
       if (iPrintResultsMode > 0)  call PrintResults
       if (lWriteJSON) then
-        open(1, file= DATA_DIRECTORY // '../outputs/thermoout.json', &
+        open(1, file= cOutputFullPath, &
             status='OLD', position='append', action='write')
         if ((i > 0) .OR. (j > 0)) write(1,*) ','
         write(intStr,*) nSim
@@ -115,7 +118,7 @@ program ThermochimicaInputScriptMode
   end do
 
   if (lWriteJSON) then
-    open(1, file= DATA_DIRECTORY // '../outputs/thermoout.json', &
+    open(1, file= cOutputFullPath, &
         status='OLD', position='append', action='write')
     write(1,*) '}'
     close (1)

--- a/src/module/ModuleThermoIO.f90
+++ b/src/module/ModuleThermoIO.f90
@@ -83,7 +83,7 @@ module ModuleThermoIO
 
 contains
 
-    pure logical function PathIsAbsolute(path)
+    logical function PathIsAbsolute(path)
 
         character(*), intent(in) :: path
         character(len(path)) :: trimmed

--- a/src/module/ModuleThermoIO.f90
+++ b/src/module/ModuleThermoIO.f90
@@ -58,6 +58,7 @@ module ModuleThermoIO
     character(15)                            :: cInputUnitTemperature, cInputUnitPressure, cInputUnitMass
     character(:), allocatable                :: cThermoFileName
     character(:), allocatable                :: cOutputFilePath
+    character(:), allocatable                :: cResolvedOutputFilePath
     logical                                  :: lReinitAvailable = .FALSE., lReinitLoaded = .FALSE., lReinitRequested = .FALSE.
     logical                                  :: lStepTogether = .FALSE., lWriteJSON = .FALSE.
     logical                                  :: lFuzzyStoich = .FALSE., lGibbsMinCheck = .FALSE.
@@ -79,5 +80,73 @@ module ModuleThermoIO
     character(25), dimension(:), allocatable :: cSolnPhaseNameOut, cPureConPhaseNameOut, cSpeciesNameOut, cSpeciesPhaseOut
     logical, dimension(:), allocatable       :: lSpeciesStable
     real(8)                                  :: dHeatCapacity = 0D0, dEntropy = 0D0, dEnthalpy = 0D0
+
+contains
+
+    pure logical function PathIsAbsolute(path)
+
+        character(*), intent(in) :: path
+        character(len(path)) :: trimmed
+        integer :: n
+
+        trimmed = adjustl(path)
+        n = len_trim(trimmed)
+
+        if (n <= 0) then
+            PathIsAbsolute = .FALSE.
+        else if ((trimmed(1:1) == '/') .OR. (trimmed(1:1) == '\\')) then
+            PathIsAbsolute = .TRUE.
+        else if (n >= 2) then
+            PathIsAbsolute = (trimmed(2:2) == ':')
+        else
+            PathIsAbsolute = .FALSE.
+        end if
+
+    end function PathIsAbsolute
+
+    subroutine SetDefaultOutputFilePath()
+
+        call UpdateOutputFilePath('../outputs/thermoout.json')
+
+    end subroutine SetDefaultOutputFilePath
+
+    subroutine UpdateOutputFilePath(rawPath)
+
+        character(*), intent(in) :: rawPath
+        character(len(rawPath)) :: cleaned
+        integer :: n
+
+        cleaned = adjustl(rawPath)
+        n = len_trim(cleaned)
+
+        if (n <= 0) then
+            cOutputFilePath = '../outputs/thermoout.json'
+            cResolvedOutputFilePath = DATA_DIRECTORY // '../outputs/thermoout.json'
+            return
+        end if
+
+        cOutputFilePath = cleaned(1:n)
+
+        if (PathIsAbsolute(cleaned(1:n))) then
+            cResolvedOutputFilePath = cleaned(1:n)
+        else if ((INDEX(cleaned(1:n), '/') == 0) .AND. (INDEX(cleaned(1:n), '\\') == 0)) then
+            cResolvedOutputFilePath = DATA_DIRECTORY // '../outputs/' // cleaned(1:n)
+        else
+            cResolvedOutputFilePath = DATA_DIRECTORY // cleaned(1:n)
+        end if
+
+    end subroutine UpdateOutputFilePath
+
+    function GetResolvedOutputFilePath() result(path)
+
+        character(:), allocatable :: path
+
+        if (.NOT. allocated(cResolvedOutputFilePath)) then
+            call SetDefaultOutputFilePath()
+        end if
+
+        path = cResolvedOutputFilePath
+
+    end function GetResolvedOutputFilePath
 
 end module ModuleThermoIO

--- a/src/parser/ParseInput.f90
+++ b/src/parser/ParseInput.f90
@@ -61,6 +61,7 @@ subroutine ParseInput(cInputFileName,dTempLow,dTempHigh,dDeltaT,dPressLow,dPress
   ! lWriteJSON true by default
   lWriteJSON = .TRUE.
   cOutputFilePathTemp = '../outputs/thermoout.json'
+  call SetDefaultOutputFilePath()
   ! Open input file
   open (UNIT = 1, FILE = cInputFileName, STATUS = 'old', ACTION = 'read', IOSTAT = INFO)
   ! Check for error on attempt to open
@@ -243,7 +244,7 @@ subroutine ParseInput(cInputFileName,dTempLow,dTempHigh,dDeltaT,dPressLow,dPress
           print *, trim(cErrMsg)
           return
         end if
-        cOutputFilePath = cOutputFilePathTemp
+        call UpdateOutputFilePath(cOutputFilePathTemp)
       case ('data','Data','data_file','Data_file','data file','Data file','Data File',&
         'dat','Dat','dat_file','Dat_file','dat file','Dat file','Dat File')
         read(cValue,'(A)',IOSTAT = INFO) cThermoFileNameTemp

--- a/src/postprocess/WriteJSON.F90
+++ b/src/postprocess/WriteJSON.F90
@@ -9,13 +9,16 @@ subroutine WriteJSON(append)
     logical, intent(in) :: append
     logical :: exist
     integer :: i, c, nElectron, its
+    character(:), allocatable :: cOutputFullPath
 
-    inquire(file= DATA_DIRECTORY // cOutputFilePath, exist=exist)
+    cOutputFullPath = GetResolvedOutputFilePath()
+
+    inquire(file= cOutputFullPath, exist=exist)
     if (append .AND. exist) then
-        open(1, file= DATA_DIRECTORY // cOutputFilePath, &
+        open(1, file= cOutputFullPath, &
               status='OLD', position='append', action='write')
     else
-        open(1, file= DATA_DIRECTORY // cOutputFilePath, &
+        open(1, file= cOutputFullPath, &
               status='REPLACE', action='write')
     end if
 


### PR DESCRIPTION
## Summary
- add helper routines in `ModuleThermoIO` to normalize the JSON output path, including support for absolute and relative user-specified destinations
- update the input parsers and executables to use the centralized path resolution so JSON files are created at the requested location
- adjust the JSON writer to rely on the resolved path for both creation and appending operations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cafb379d1083229d6cf8f56fea3680